### PR TITLE
Fix CI script to check out PR head and use DEPLOY_KEY only for cloning Framework X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Deploy
 
+# Uses "pull_request_target" to expose the DEPLOY_KEY secret to PRs from forks in order to allow installing Framework X from a private repository.
+# We need to explicitly check out the PR head which may potentially expose the secrets to malicious PR authors.
+# Accordingly, we use the DEPLOY_KEY only to clone Framework X and then discard its value before running commands from the Makefile.
+# Additionally, the DEPLOY_KEY is limited in scope may change over time.
 on:
   push:
   pull_request_target:
@@ -10,8 +14,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: mkdir -p ~/.ssh && echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa && chmod 400 ~/.ssh/id_rsa
       - run: git config --global user.name "GitHub Actions" && git config --global user.email "actions@github.com"
+      - run: git clone git@github.com:clue-access/framework-x.git source/
+      - run: rm -r ~/.ssh/id_rsa
+        if: ${{ github.event_name == 'pull_request_target' }}
       - run: make
       - run: make served
       - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 build:
 	mkdir -p build/src/
-	test -d source/ && git -C source/ pull || git clone git@github.com:clue-access/framework-x.git source/
-	php -r 'file_put_contents("source/mkdocs.yml",preg_replace("/(theme:)(\n +)/","$$1$$2custom_dir: overrides/$$2",file_get_contents("source/mkdocs.yml")));'
+	test -d source/ || $(MAKE) pull
+	php -r 'file_put_contents("source/mkdocs.yml",preg_replace("/(theme:)(\n +)(?:custom_dir: .*?\n +)?/","$$1$$2custom_dir: overrides/$$2",file_get_contents("source/mkdocs.yml")));'
 	mkdir -p source/overrides
 	cp overrides/* source/overrides/
 	docker run --rm -i -v ${PWD}/source:/docs -u $(shell id -u) squidfunk/mkdocs-material build
 	cp -r source/build/docs/ build/
 	cp .htaccess index.html build/
 	cp src/* build/src/
+
+pull:
+	test -d source/ && git -C source/ pull || git clone git@github.com:clue-access/framework-x.git source/
 
 serve: build
 	docker run -it --rm -p 8080:80 -v "$$PWD"/build:/usr/local/apache2/htdocs/ httpd:2.4-alpine sh -c \
@@ -33,4 +36,4 @@ deploy:
 clean:
 	rm -rf source/ build/
 
-.PHONY: build serve served test deploy clean
+.PHONY: build pull serve served test deploy clean

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ $ make
 > Note that this command will clone Framework X which is currently in early access.
   See https://github.com/clue/framework-x for more details.
 
+If you've pulled Framework X before and want to update its source code, you can
+pull an up-to-date version and rebuild the website like this:
+
+```bash
+$ make pull
+$ make
+```
+
 Once built, you can manually browse the `build/` directory or run the web server
 container (Apache) in the foreground like this:
 


### PR DESCRIPTION
This changeset fixes the CI script to actually check out the PR head and use the DEPLOY_KEY secret only for cloning Framework X.

Without these changes, we only run tests against the current `main` branch and do not actually test the PR contents (noticed this in https://github.com/clue-engineering/justkanban/pull/35 (private)).

Builds on top of #10, #9 and #7
Refs https://securitylab.github.com/research/github-actions-preventing-pwn-requests/, https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/, https://getcomposer.org/doc/articles/authentication-for-private-packages.md#github-oauth, https://getcomposer.org/doc/03-cli.md#composer-auth