### PR TITLE
Typo in coroutines docs

### DIFF
--- a/docs/async/coroutines/index.html
+++ b/docs/async/coroutines/index.html
@@ -1013,7 +1013,7 @@ you use the <code>yield</code> statement anywhere in your controller function.</
 for more details.</p>
 <h2 id="faq">FAQ<a class="headerlink" href="#faq" title="Permanent link">&para;</a></h2>
 <h3 id="when-to-coroutines">When to coroutines?<a class="headerlink" href="#when-to-coroutines" title="Permanent link">&para;</a></h3>
-<p>As a rule of thumb, you'll likely want to use fibers when you're working with
+<p>As a rule of thumb, you'll likely want to use coroutines when you're working with
 async APIs in your controllers with PHP &lt; 8.1 and want to use these async APIs
 in a way that resembles a synchronous code flow.</p>
 <p>We also provide support for <a href="../fibers/">fibers</a> which can be seen as an


### PR DESCRIPTION
Copy paste error I guess, should mention coroutines for php < 8.1, next paragraph mentions fibers.