### PR TITLE
Re-add `workflow_dispatch` trigger to deploy website when docs change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Deploy
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   Deploy:


### PR DESCRIPTION
This changeset fixes the automatic website deployment by re-adding the `workflow_dispatch` trigger to deploy website when docs change.

Fixes deployment broken via #18
Refs #7 and https://github.com/clue/framework-x/pull/32