### PR TITLE
Add compression to dev environment to match production configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,17 @@ pull:
 
 serve: build
 	docker run -it --rm -p 8080:80 -v "$$PWD"/build:/usr/local/apache2/htdocs/ httpd:2.4-alpine sh -c \
-	  "echo 'LoadModule rewrite_module modules/mod_rewrite.so' >> conf/httpd.conf;sed -i 's/AllowOverride None/AllowOverride All/' conf/httpd.conf;httpd -DFOREGROUND"
+	  "echo 'LoadModule rewrite_module modules/mod_rewrite.so' >> conf/httpd.conf && \
+	  echo 'LoadModule deflate_module modules/mod_deflate.so' >> conf/httpd.conf && \
+	  echo 'LoadModule brotli_module modules/mod_brotli.so' >> conf/httpd.conf && \
+	  echo 'AddOutputFilterByType BROTLI_COMPRESS;DEFLATE text/html' >> conf/httpd.conf;sed -i 's/AllowOverride None/AllowOverride All/' conf/httpd.conf;httpd -DFOREGROUND"
 
 served: build
 	docker run -d --rm -p 8080:80 -v "$$PWD"/build:/usr/local/apache2/htdocs/ httpd:2.4-alpine sh -c \
-	  "echo 'LoadModule rewrite_module modules/mod_rewrite.so' >> conf/httpd.conf;sed -i 's/AllowOverride None/AllowOverride All/' conf/httpd.conf;httpd -DFOREGROUND"
+	  "echo 'LoadModule rewrite_module modules/mod_rewrite.so' >> conf/httpd.conf && \
+	  echo 'LoadModule deflate_module modules/mod_deflate.so' >> conf/httpd.conf && \
+	  echo 'LoadModule brotli_module modules/mod_brotli.so' >> conf/httpd.conf && \
+	  echo 'AddOutputFilterByType BROTLI_COMPRESS;DEFLATE text/html' >> conf/httpd.conf;sed -i 's/AllowOverride None/AllowOverride All/' conf/httpd.conf;httpd -DFOREGROUND"
 	@sleep 2
 	@echo Container running. Use \"docker rm -f {containerId}\" to stop container.
 

--- a/tests/integration.bash
+++ b/tests/integration.bash
@@ -21,9 +21,17 @@ skipif() {
 
 # check index endpoint
 
-curl -v $base/
+curl -v $base/ --compressed
 match "HTTP/.* 200"
 match -iP "Content-Type: text/html[\r\n]"
+match -iP "Content-Encoding: br[\r\n]"
+match -iP "Vary: Accept-Encoding[\r\n]"
+
+curl -v $base/ --compressed -H 'Accept-Encoding: gzip, deflate'
+match "HTTP/.* 200"
+match -iP "Content-Type: text/html[\r\n]"
+match -iP "Content-Encoding: gzip[\r\n]"
+match -iP "Vary: Accept-Encoding[\r\n]"
 
 curl -v $base/invalid
 match "HTTP/.* 404"


### PR DESCRIPTION
This pull request improves the configuration for the dev environment by enabling HTTP compression (brotli and gzip). Our production system uses a content delivery network (CDN) which uses brotli compression by default with a possible fallback to gzip. Our current dev environment configuration doesn't allow compression, which will change through my suggestion and thus better aligns our production environment and our dev environment.

As a first step, I made sure that our production system works with the improved integration tests like this:
```php
bash tests/integration.bash https://framework-x.org
```
Once the test suite confirmed my changes, I improved the dev configuration and ran the same tests against the new dev environment:
```php
bash tests/integration.bash
``` 

This is also confirmed by our automated test suite (which uses dev environment), so I think this pull request is save to apply and will have no impact on the production system :+1:

Builds on top of #40 and others.